### PR TITLE
Use runtime libraries

### DIFF
--- a/fm.cancel.Ripcord.yaml
+++ b/fm.cancel.Ripcord.yaml
@@ -1,9 +1,11 @@
 app-id: fm.cancel.Ripcord
-runtime: org.freedesktop.Platform
-runtime-version: '24.08'
-sdk: org.freedesktop.Sdk
+runtime: org.kde.Platform
+runtime-version: '5.15-24.08'
+sdk: org.kde.Sdk
 finish-args:
-  - --socket=x11
+  - --device=dri
+  - --socket=fallback-x11
+  - --socket=wayland
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
@@ -39,6 +41,9 @@ modules:
       - install -Dm 644 ./squashfs-root/Ripcord_Icon.png -t /app/share/icons/hicolor/512x512/apps/
       - install -Dm 644 fm.cancel.Ripcord.metainfo.xml -t /app/share/metainfo/
       - rm -fr ./squashfs-root/.DirIcon ./squashfs-root/AppRun
+      - rm -fr ./squashfs-root/lib/libEGL.so.* ./squashfs-root/lib/libgbm.so.* ./squashfs-root/lib/libglapi.so.*
+      - rm -fr ./squashfs-root/lib/libwayland-* ./squashfs-root/lib/libX* ./squashfs-root/lib/libxcb-* ./squashfs-root/lib/libxshmfence.so.*
+      - rm -fr ./squashfs-root/lib/libcrypto.so.* ./squashfs-root/lib/libssl.so.* ./squashfs-root/lib/libicu* ./squashfs-root/lib/libQt5* ./squashfs-root/plugins/ ./squashfs-root/qt.conf
       - rm -fr ./squashfs-root/Ripcord.desktop ./squashfs-root/Ripcord_Icon.png
       - cp -r ./squashfs-root/ /app/share/ripcord/
       - mkdir -p /app/bin/

--- a/fm.cancel.Ripcord.yaml
+++ b/fm.cancel.Ripcord.yaml
@@ -13,6 +13,9 @@ finish-args:
 
 command: Ripcord
 
+rename-desktop-file: Ripcord.desktop
+rename-icon: Ripcord_Icon
+
 modules:
   - name: Ripcord
     buildsystem: simple
@@ -31,10 +34,12 @@ modules:
     build-commands:
       - chmod +x ./Ripcord.AppImage
       - ./Ripcord.AppImage --appimage-extract
-      - install -dm 755 /app/bin
-      - mv ./squashfs-root/Ripcord ./squashfs-root/lib ./squashfs-root/plugins ./squashfs-root/translations /app/bin
-      - mv ./squashfs-root/twemoji.ripdb ./squashfs-root/qt.conf /app/bin
-      - install -Dm 644 ./squashfs-root/Ripcord_Icon.png /app/share/icons/hicolor/512x512/apps/fm.cancel.Ripcord.png
-      - install -Dm 644 ./squashfs-root/Ripcord.desktop /app/share/applications/fm.cancel.Ripcord.desktop
-      - desktop-file-edit --set-key="Icon" --set-value="fm.cancel.Ripcord" /app/share/applications/fm.cancel.Ripcord.desktop
-      - install -Dm 644 fm.cancel.Ripcord.metainfo.xml /app/share/metainfo/fm.cancel.Ripcord.metainfo.xml
+      - mkdir -p /app/share/
+      - install -Dm 644 ./squashfs-root/Ripcord.desktop -t /app/share/applications/
+      - install -Dm 644 ./squashfs-root/Ripcord_Icon.png -t /app/share/icons/hicolor/512x512/apps/
+      - install -Dm 644 fm.cancel.Ripcord.metainfo.xml -t /app/share/metainfo/
+      - rm -fr ./squashfs-root/.DirIcon ./squashfs-root/AppRun
+      - rm -fr ./squashfs-root/Ripcord.desktop ./squashfs-root/Ripcord_Icon.png
+      - cp -r ./squashfs-root/ /app/share/ripcord/
+      - mkdir -p /app/bin/
+      - ln -s /app/share/ripcord/Ripcord /app/bin/Ripcord


### PR DESCRIPTION
Use Qt libraries (and their dependencies) provided by runtime `org.kde.Platform`.

This pull request will:

- Add Wayland support.
- Apply multiple years of bug fixes and security patches for the replaced libraries.